### PR TITLE
Remove dependency on logs, and execute only from the admin area.

### DIFF
--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -350,6 +350,16 @@ class Perfecty_Push_Admin {
 	}
 
 	/**
+	 * Executes the cron check. Note that this will only run
+	 * when the admin area is loaded (uses the `admin_init` hook)
+	 */
+	public function check_cron() {
+		// This cron check is only intended to be run from the admin area, or
+		// when the `admin_init` hook is called
+		Perfecty_Push_Lib_Cron_Check::run();
+	}
+
+	/**
 	 * Execute the next broadcast batch
 	 * This is a WordPress action called from wp-cron
 	 *
@@ -496,29 +506,10 @@ class Perfecty_Push_Admin {
 
 			delete_transient( 'perfecty_push_admin_notice' );
 		}
-
-		$cron_check_status = Perfecty_Push_Lib_Cron_Check::get_cron_status();
-
-		if ( ! $cron_check_status ) {
-			$message  = esc_html__( 'It seems no cron system is working.', 'perfecty-push-notifications' ) . '</b><br />';
-			$message .= esc_html__( 'Perfecty Push Notifications uses scheduled actions to make its magic.', 'perfecty-push-notifications' ) . ' ';
-			$message .= sprintf(
-				// translators: %1$s is the opening a tag
-				// translators: %2$s is the closing a tag
-				esc_html__(
-					'Please, check your wp-config.php to assure %1$sDISABLE_WP_CRON%2$s is not set to \'true\' ' .
-					'and/or a system cron action is set in your server to periodically call wp-cron.php',
-					'perfecty-push-notifications'
-				),
-				'<a href="https://developer.wordpress.org/plugins/cron/hooking-wp-cron-into-the-system-task-scheduler/" target="_blank">',
-				'</a>'
-			);
-			Class_Perfecty_Push_Lib_Utils::show_message( $message, 'warning' );
-		}
 	}
 
 	/**
-	 * Renders the f page
+	 * Renders the dashboard page
 	 *
 	 * @since 1.0.0
 	 */

--- a/includes/class-perfecty-push.php
+++ b/includes/class-perfecty-push.php
@@ -244,9 +244,6 @@ class Perfecty_Push {
 	 * @access   private
 	 */
 	private function define_global_hooks() {
-		$cron_check = new Perfecty_Push_Lib_Cron_Check();
-		$this->loader->add_action( 'perfecty_push_cron_check', $cron_check, 'schedule_cron_job' );
-
 		$global = new Perfecty_Push_Global();
 		$this->loader->add_action( 'plugins_loaded', $global, 'upgrade_check' );
 	}
@@ -261,10 +258,12 @@ class Perfecty_Push {
 	private function define_admin_hooks() {
 		$plugin_admin = new Perfecty_Push_Admin( $this->get_plugin_name(), $this->get_version() );
 
+		$this->loader->add_action( Perfecty_Push_Lib_Cron_Check::HOOK, Perfecty_Push_Lib_Cron_Check::class, 'tick' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_admin_menu' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_options' );
+		$this->loader->add_action( 'admin_init', $plugin_admin, 'check_cron' );
 		$this->loader->add_action( 'perfecty_push_broadcast_notification_event', $plugin_admin, 'execute_broadcast_batch', 10, 1 );
 		$this->loader->add_action( 'add_meta_boxes', $plugin_admin, 'register_metaboxes' );
 		$this->loader->add_action( 'save_post', $plugin_admin, 'on_save_post' );

--- a/lib/class-perfecty-push-lib-cron-check.php
+++ b/lib/class-perfecty-push-lib-cron-check.php
@@ -7,120 +7,73 @@ use Perfecty_Push_Lib_Log as Log;
  */
 class Perfecty_Push_Lib_Cron_Check {
 
-	private const CRON_HOOK = 'perfecty_push_cron_check';
-
-	private const SCHEDULE_OFFSET = 1800; // 30 minutes
-
-	private const SUCCESS_RUN_LOG_MSG = 'Cron monitor runned';
-
-	private const NEXT_SCHED_LOG_MSG = 'Next cron check scheduled at: ';
-
-	private const NEVER_SCHED_LOG_MSG = 'Cron monitor was not scheduled';
-
-	private const NOT_RUNNED_LOG_MSG = 'Cron monitor was scheduled but not executed';
-
-	private const LIMIT_LOGS_FOR_CALC = 10;
+	public const HOOK             = 'perfecty_push_cron_check';
+	private const FAILURES_COUNT  = 'perfecty_push_cron_failures';
+	private const SCHEDULE_OFFSET = 60; // 60 seconds
+	private const MAX_DIFF        = 60; // 60 seconds
+	private const THRESHOLD       = 3; // consider error after 3 failures
 
 	/**
-	 * The cron running status.
-	 *
-	 * @since    1.2.0
-	 * @access   private
-	 * @var      bool    $cron_working    The cron running status.
+	 * Runs the ticker and checks if the executions are correctly done
 	 */
-	private static $cron_working = false;
-
-	/**
-	 * Initialize the class.
-	 *
-	 * @since    1.2.0
-	 */
-	public function __construct() {
-		$this->schedule_cron_job();
-	}
-
-	/**
-	 * Schedules the cron job once (this is the callback of the cronjob too).
-	 */
-	public function schedule_cron_job() {
-		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			$now                 = time();
-			$next_scheduled_time = $now + self::SCHEDULE_OFFSET;
-			wp_schedule_single_event( $next_scheduled_time, self::CRON_HOOK );
-			Log::info(
-				self::SUCCESS_RUN_LOG_MSG . ' - ' . self::NEXT_SCHED_LOG_MSG . \
-				get_date_from_gmt( gmdate( 'Y-m-d H:i:s', intval( $next_scheduled_time ) ) ),
-				'Y-m-d H:i:s'
-			);
+	public static function run() {
+		// if the ticker is not running, we schedule it
+		$scheduled = wp_next_scheduled( self::HOOK );
+		if ( $scheduled === false ) {
+			self::schedule_next_tick();
+			return;
 		}
-	}
 
-	/**
-	 * Checks if next scheduled action is in the future and returns cron status
-	 *
-	 * @return bool
-	 */
-	public static function get_cron_status() {
-		$now = time();
-		/**
-		 * When wp-cron is disabled and a system cron is running we don't want to annoy users
-		 * with a false positive warning. In this scenario, a false positive (a warning saying
-		 * that no cron is set) could arise when the system's cron is set to call wp-cron.php
-		 * with a period (let's call it SYSCRON_PERIOD) longer than SCHEDULE_OFFSET.
-		 * We cannot directly read system cron settings, but we can guess the real periodicity
-		 * (given by the combination of the 2 periods) by reading our logs (when enabled).
-		 *
-		 * The REAL_PERIOD (we estimate) will be equal to the SYSCRON_PERIOD when this
-		 * is bigger (longer) than SCHEDULE_OFFSET.
-		 * If SYSCRON_PERIOD is smaller (shorter) than SCHEDULE_OFFSET it will be in range
-		 * [SCHEDULE_OFFSET; 2x SCHEDULE_OFFSET[
-		 *
-		 * The REAL_PERIOD can be calculated using this formula:
-		 *
-		 * IF ( SCHEDULE_OFFSET Mod ( SYSCRON_PERIOD ) > 0 ) {
-		 *      REAL_PERIOD = SCHEDULE_OFFSET + SYSCRON_PERIOD - ( SCHEDULE_OFFSET Mod ( SYSCRON_PERIOD ) )
-		 * } ELSE {
-		 *      REAL_PERIOD = SCHEDULE_OFFSET
-		 * }
-		 */
-		if ( ( ! self::is_wp_cron_enabled() ) && self::are_logs_enabled() ) {
-			$last_success_logs = self::get_success_logs();
-			$sys_cron_offset   = self::get_estimated_system_cron_offset( $last_success_logs );
-			if ( $sys_cron_offset ) {
-				$last_success_log = self::get_last_success_log( $last_success_logs );
-				$scheduled        = $sys_cron_offset + $last_success_log;
-			} else {
-				$scheduled = wp_next_scheduled( self::CRON_HOOK );
+		// get the failures count and the diff between scheduled and the current time
+		$failures_count = get_option( self::FAILURES_COUNT );
+		$diff           = $scheduled - time();
+
+		if ( $diff < 0 && abs( $diff ) > self::MAX_DIFF ) {
+			// something is wrong: even though it was scheduled in the future,
+			// it is still scheduled but in the past and the difference is longer than
+			// MAX_DIFF seconds. This means the cron is not running properly in this cycle
+			Log::error( 'Scheduled event was not executed, diff: ' . $diff . 's, failed attempt: ' . ( $failures_count + 1 ) );
+
+			// increment failures count and un-schedule the event so that it's checked again after some minutes
+			update_option( self::FAILURES_COUNT, $failures_count + 1 );
+			wp_unschedule_event( $scheduled, self::HOOK );
+		}
+
+		if ( $failures_count >= self::THRESHOLD ) {
+			if ( ! self::is_wp_cron_enabled() ) {
+				Log::warning( 'WP Cron is disabled' );
 			}
-		} else {
-			$scheduled = wp_next_scheduled( self::CRON_HOOK );
+
+			// we have failed more than the threshold, we consider the cron is not
+			// correctly working and we show the warning
+			self::show_warning();
+			Log::error( 'Multiple cron checks have failed. Please check your cron configuration.' );
 		}
-		if ( false === $scheduled ) {
-			Log::debug( self::NEVER_SCHED_LOG_MSG );
-			return false;
-		}
-		if ( intval( $scheduled ) < $now ) {
-			// We have a false positive in small/no traffice server, if the page that triggers wp-cron is Perfecty Push Admin.
-			Log::debug( self::NOT_RUNNED_LOG_MSG );
-			return false;
-		}
-		self::$cron_working = true;
-		return true;
 	}
 
 	/**
-	 * Checks if logs functionality is enabled
-	 *
-	 * @return bool
+	 * This is the function being called on every scheduled event. It
+	 * resets the failures count.
 	 */
-	private static function are_logs_enabled() {
-		$options          = get_option( 'perfecty_push', array() );
-		$are_logs_enabled = isset( $options['logs_enabled'] ) ? $options['logs_enabled'] : '';
-		if ( '' === $are_logs_enabled ) {
-			return false;
-		} else {
-			return true;
-		}
+	public static function tick() {
+		// reset failures count
+		update_option( self::FAILURES_COUNT, 0 );
+
+		Log::info( 'Cron check ticked' );
+	}
+
+	/**
+	 * Schedules the execution of just one tick
+	 */
+	private static function schedule_next_tick() {
+		$next_scheduled_time = time() + self::SCHEDULE_OFFSET;
+		wp_schedule_single_event( $next_scheduled_time, self::HOOK );
+
+		Log::info(
+			'Next ticker scheduled at: ' .
+			get_date_from_gmt( gmdate( 'Y-m-d H:i:s', intval( $next_scheduled_time ) ) ),
+			'Y-m-d H:i:s'
+		);
 	}
 
 	/**
@@ -129,89 +82,27 @@ class Perfecty_Push_Lib_Cron_Check {
 	 * @return bool
 	 */
 	private static function is_wp_cron_enabled() {
-		return ! ( var_export( DISABLE_WP_CRON, true ) ); // phpcs:ignore
+		return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON );
 	}
 
 	/**
-	 * Returns an array of rows indexed from 0 of the last 10 (LIMIT_LOGS_FOR_CALC) SUCCESS_RUN_LOG_MSG
-	 *
-	 * @return array
+	 * Shows the warning message
 	 */
-	private static function get_success_logs() {
-		global $wpdb;
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT UNIX_TIMESTAMP(created_at)' .
-				' FROM ' . $wpdb->prefix . 'perfecty_push_logs' .
-				' WHERE message LIKE %s' .
-				' ORDER BY created_at desc ' .
-				' LIMIT %d OFFSET %d',
-				$wpdb->esc_like( self::SUCCESS_RUN_LOG_MSG ) . '%',
-				self::LIMIT_LOGS_FOR_CALC,
-				0
+	private static function show_warning() {
+		$message  = esc_html__( 'It seems no cron system is working.', 'perfecty-push-notifications' ) . '</b><br />';
+		$message .= esc_html__( 'Perfecty Push Notifications uses scheduled actions to execute the notification jobs.', 'perfecty-push-notifications' ) . ' ';
+		$message .= sprintf(
+		// translators: %1$s is the opening a tag
+		// translators: %2$s is the closing a tag
+			esc_html__(
+				'Please, check your wp-config.php to assure %1$sDISABLE_WP_CRON%2$s is not set to \'true\' ' .
+				'and/or a system cron action is set in your server to periodically call wp-cron.php',
+				'perfecty-push-notifications'
 			),
-			ARRAY_N
+			'<a href="https://developer.wordpress.org/plugins/cron/hooking-wp-cron-into-the-system-task-scheduler/" target="_blank">',
+			'</a>'
 		);
-		foreach ( $rows as $row ) {
-			$results[] = $row[0];
-		}
-		return $results;
+		Class_Perfecty_Push_Lib_Utils::show_message( $message, 'warning' );
 	}
 
-	/**
-	 * Returns a value that is the average (max between avg and median) difference beetween last success executions of the monitor
-	 *
-	 * @param array $success_logs An array of the last (max) 10 success check logged.
-	 * @return int|false
-	 */
-	private static function get_estimated_system_cron_offset( $success_logs ) {
-
-		$num_logs = count( $success_logs );
-
-		if ( $num_logs < 2 ) {
-			return false;
-		} else {
-			sort( $success_logs );
-
-			$sum = 0;
-			$med = 0;
-			$avg = 0;
-
-			$i = 1;
-			while ( $i < $num_logs ) {
-				$offset    = ( intval( $success_logs[ $i ] ) - intval( $success_logs[ $i - 1 ] ) );
-				$offsets[] = $offset;
-				$sum      += $offset;
-				$i++;
-			}
-			$num_offsets = count( $offsets );
-
-			// Median value.
-			sort( $offsets );
-			$middleval = floor( ( $num_offsets - 1 ) / 2 ); // find the middle value, or the lowest middle value.
-			if ( $num_offsets % 2 ) { // odd number, middle is the median.
-				$med = $offsets[ $middleval ];
-			} else { // even number, calculate avg of 2 medians.
-				$low  = $offsets[ $middleval ];
-				$high = $offsets[ $middleval + 1 ];
-				$med  = intval( ( $low + $high ) / 2 );
-			}
-
-			// Average value.
-			$avg = round( $sum / $num_offsets );
-		}
-		$max_value = max( $med, $avg );
-		return $max_value;
-	}
-
-	/**
-	 * Returns a value that is the average (max avg and median) difference beetween last success execution times of the monitor
-	 *
-	 * @param array $success_logs An array of the last (max) 10 success check logged.
-	 * @return int|false
-	 */
-	private static function get_last_success_log( $success_logs ) {
-		rsort( $success_logs );
-		return $success_logs[0];
-	}
 }

--- a/public/class-perfecty-push-public.php
+++ b/public/class-perfecty-push-public.php
@@ -99,16 +99,16 @@ class Perfecty_Push_Public {
 				'permission_callback' => '__return_true',
 			)
 		);
-        register_rest_route(
-            'perfecty-push',
-            '/v1/public/users/(?P<user_id>[a-zA-Z0-9-]+)/unregister',
-            array(
-                'methods'             => array( 'POST' ),
-                'callback'            => array( $users, 'unregister' ),
-                'permission_callback' => '__return_true',
-                'args'                => array( 'user_id' => array() ),
-            )
-        );
+		register_rest_route(
+			'perfecty-push',
+			'/v1/public/users/(?P<user_id>[a-zA-Z0-9-]+)/unregister',
+			array(
+				'methods'             => array( 'POST' ),
+				'callback'            => array( $users, 'unregister' ),
+				'permission_callback' => '__return_true',
+				'args'                => array( 'user_id' => array() ),
+			)
+		);
 		register_rest_route(
 			'perfecty-push',
 			'/v1/public/users/(?P<user_id>[a-zA-Z0-9-]+)/preferences',


### PR DESCRIPTION
@MocioF This removes the logs dependency and uses the WP options instead to keep track of the attempts. Also, it will only be checked when the user is an admin user (the job will be scheduled by the admin user and is not auto-called by himself infinitely)

Fixes #33 