### PR TITLE
Avoid potential composer conflicts

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -95,6 +95,9 @@ You can create an issue in our Github repo:
 
 == Changelog ==
 
+= 1.5.0 =
+* Use the external composer libraries only when necessary to avoid potential conflicts. Related [#111](https://github.com/perfectyorg/perfecty-push-wp/issues/111)
+
 = 1.4.2 =
 * Set the default log level to ERROR. Related [#117](https://github.com/perfectyorg/perfecty-push-wp/issues/117)
 * Move the cron job check warning to the logger. Related [#110](https://github.com/perfectyorg/perfecty-push-wp/issues/110)

--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -605,7 +605,7 @@ class Perfecty_Push_Admin {
 
 			if ( $result === false ) {
 				error_log( esc_html__( 'Could not schedule the broadcast async, check the logs', 'perfecty-push-notifications' ) );
-				Class_Perfecty_Push_Lib_Utils::show_message( esc_html__( 'Could not send the notification', 'perfecty-push-notifications' ), 'error' );
+				Perfecty_Push_Lib_Utils::show_message( esc_html__( 'Could not send the notification', 'perfecty-push-notifications' ), 'error' );
 			} else {
 				if ( isset( $_POST['perfecty_push_post_metabox_nonce'] ) ) {
 					// once we sent the notification, we reset the checkbox when the
@@ -614,7 +614,7 @@ class Perfecty_Push_Admin {
 				}
 				update_post_meta( $post->ID, '_perfecty_push_send_on_publish', false );
 
-				Class_Perfecty_Push_Lib_Utils::show_message( '<strong>Perfecty Push</strong> ' . esc_html__( 'has sent a notification for the recently published post:', 'perfecty-push-notifications' ) . ' ' . $body );
+				Perfecty_Push_Lib_Utils::show_message( '<strong>Perfecty Push</strong> ' . esc_html__( 'has sent a notification for the recently published post:', 'perfecty-push-notifications' ) . ' ' . $body );
 			}
 		}
 	}
@@ -975,7 +975,7 @@ class Perfecty_Push_Admin {
 
 		if ( empty( $options['vapid_public_key'] ) && empty( $options['vapid_private_key'] ) &&
 			! empty( $new_input['vapid_public_key'] ) && ! empty( $new_input['vapid_private_key'] ) ) {
-			Class_Perfecty_Push_Lib_Utils::clean_messages();
+			Perfecty_Push_Lib_Utils::clean_messages();
 		}
 		return $new_input;
 	}

--- a/external/class-perfecty-push-external-uuid.php
+++ b/external/class-perfecty-push-external-uuid.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class Perfecty_Push_External_Uuid
+ *
+ * UUID external wrapper
+ */
+class Perfecty_Push_External_Uuid {
+
+	/**
+	 * Check if the UUID is valid
+	 *
+	 * @return bool
+	 */
+	public static function isValid( $uuid ) {
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'vendor/autoload.php';
+		return Ramsey\Uuid\Uuid::isValid( $uuid );
+	}
+
+	/**
+	 * Return a new uuid4
+	 *
+	 * @return mixed
+	 */
+	public static function uuid4() {
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'vendor/autoload.php';
+		return Ramsey\Uuid\Uuid::uuid4();
+	}
+}

--- a/external/class-perfecty-push-external-webpush.php
+++ b/external/class-perfecty-push-external-webpush.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Class Perfecty_Push_External_Webpush
+ *
+ * WebPush external wrapper
+ */
+class Perfecty_Push_External_Webpush {
+
+	/**
+	 * Return a new webpush object
+	 *
+	 * @return WebPush
+	 * @throws ErrorException
+	 */
+	public static function get( $auth = array(), $defaultOptions = array() ) {
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'vendor/autoload.php';
+		return new Minishlink\WebPush\WebPush( $auth, $defaultOptions );
+	}
+
+	/**
+	 * Return a new webpush subscription
+	 *
+	 * @return Subscription
+	 * @throws ErrorException
+	 */
+	public static function subscription( $endpoint, $publicKey, $authToken ) {
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'vendor/autoload.php';
+		return new Minishlink\WebPush\Subscription( $endpoint, $publicKey, $authToken );
+	}
+
+	/**
+	 * Return a new set of vapid keys
+	 *
+	 * @return array
+	 * @throws ErrorException
+	 */
+	public static function createVapidKeys() {
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'vendor/autoload.php';
+		return Minishlink\WebPush\VAPID::createVapidKeys();
+	}
+}

--- a/includes/class-perfecty-push-activator.php
+++ b/includes/class-perfecty-push-activator.php
@@ -38,7 +38,7 @@ class Perfecty_Push_Activator {
 		// Verifies if we already have both the vapid_public_key and vapid_private_key
 		// If we don't, we generate them and save them
 		$options = get_option( 'perfecty_push', array() );
-		if ( empty( $options['vapid_public_key'] ) && empty( $options['vapid_private_key'] ) && Class_Perfecty_Push_Lib_Utils::is_enabled() ) {
+		if ( empty( $options['vapid_public_key'] ) && empty( $options['vapid_private_key'] ) && Perfecty_Push_Lib_Utils::is_enabled() ) {
 			$vapidKeys                    = Perfecty_Push_Lib_Push_Server::create_vapid_keys();
 			$options['vapid_public_key']  = $vapidKeys['publicKey'];
 			$options['vapid_private_key'] = $vapidKeys['privateKey'];

--- a/includes/class-perfecty-push-deactivator.php
+++ b/includes/class-perfecty-push-deactivator.php
@@ -30,7 +30,7 @@ class Perfecty_Push_Deactivator {
 	 * @since    1.0.0
 	 */
 	public static function deactivate() {
-		Class_Perfecty_Push_Lib_Utils::clean_messages();
+		Perfecty_Push_Lib_Utils::clean_messages();
 		delete_option( 'perfecty_push_activated' );
 	}
 

--- a/includes/class-perfecty-push-global.php
+++ b/includes/class-perfecty-push-global.php
@@ -38,7 +38,7 @@ class Perfecty_Push_Global {
 		$plugin_activated = get_option( 'perfecty_push_activated', 0 );
 
 		if ( $plugin_activated == 1 ) {
-			Class_Perfecty_Push_Lib_Utils::check_database();
+			Perfecty_Push_Lib_Utils::check_database();
 		}
 
 		if ( get_option( 'perfecty_push_version' ) != PERFECTY_PUSH_VERSION ) {

--- a/includes/class-perfecty-push.php
+++ b/includes/class-perfecty-push.php
@@ -78,7 +78,7 @@ class Perfecty_Push {
 		$this->load_dependencies();
 		$this->load_logger();
 		$this->set_locale();
-		if ( Class_Perfecty_Push_Lib_Utils::is_enabled() ) {
+		if ( Perfecty_Push_Lib_Utils::is_enabled() ) {
 			$this->load_push_server();
 		}
 		$this->define_global_hooks();
@@ -215,7 +215,7 @@ class Perfecty_Push {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-perfecty-push-admin-logs-table.php';
 
 		/**
-		 * Contains the lib/ definitions
+		 * Contains the lib/ and external/ definitions
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'lib/class-perfecty-push-lib-db.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'lib/class-perfecty-push-lib-push-server.php';
@@ -225,6 +225,8 @@ class Perfecty_Push {
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'lib/log/class-perfecty-push-lib-log-db.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'lib/log/class-perfecty-push-lib-log-errorlog.php';
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'lib/class-perfecty-push-lib-cron-check.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'external/class-perfecty-push-external-uuid.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'external/class-perfecty-push-external-webpush.php';
 		$this->loader = new Perfecty_Push_Loader();
 	}
 
@@ -280,11 +282,11 @@ class Perfecty_Push {
 			);
 		} elseif ( $plugin_activated == 1 ) {
 			error_log( 'VAPID Keys are missing' );
-			Class_Perfecty_Push_Lib_Utils::show_message( sprintf( esc_html( 'The VAPID keys are missing in Perfecty Push. Help: %1$s Generate the VAPID Keys. %2$s', 'perfecty-push-notifications' ), "<a href='https://docs.perfecty.org/wp/troubleshooting/#the-vapid-keys-are-missing-in-perfecty-push-generate-the-vapid-keys' target='_blank'>", '</a>' ), 'warning' );
-			Class_Perfecty_Push_Lib_Utils::disable();
+			Perfecty_Push_Lib_Utils::show_message( sprintf( esc_html( 'The VAPID keys are missing in Perfecty Push. Help: %1$s Generate the VAPID Keys. %2$s', 'perfecty-push-notifications' ), "<a href='https://docs.perfecty.org/wp/troubleshooting/#the-vapid-keys-are-missing-in-perfecty-push-generate-the-vapid-keys' target='_blank'>", '</a>' ), 'warning' );
+			Perfecty_Push_Lib_Utils::disable();
 			return false;
 		}
-		$vapid_generator = array( 'Minishlink\WebPush\VAPID', 'createVapidKeys' );
+		$vapid_generator = array( 'Perfecty_Push_External_Webpush', 'createVapidKeys' );
 
 		Perfecty_Push_Lib_Push_Server::bootstrap( $auth, $vapid_generator );
 		return true;

--- a/lib/class-perfecty-push-lib-db.php
+++ b/lib/class-perfecty-push-lib-db.php
@@ -1,6 +1,6 @@
 <?php
 
-use Ramsey\Uuid\Uuid;
+use Perfecty_Push_External_Uuid as Uuid;
 
 /***
  * DB library

--- a/lib/class-perfecty-push-lib-push-server.php
+++ b/lib/class-perfecty-push-lib-push-server.php
@@ -1,7 +1,5 @@
 <?php
 
-use Minishlink\WebPush\Subscription;
-use Minishlink\WebPush\WebPush;
 use Perfecty_Push_Lib_Log as Log;
 
 /***
@@ -67,12 +65,12 @@ class Perfecty_Push_Lib_Push_Server {
 			}
 		);
 		try {
-			$webpush = new WebPush( self::$auth, array( 'batchSize' => $parallel_flushing_size ) );
+			$webpush = Perfecty_Push_External_Webpush::get( self::$auth, array( 'batchSize' => $parallel_flushing_size ) );
 			$webpush->setReuseVAPIDHeaders( true );
 		} catch ( Throwable $ex ) {
 			Log::error( 'Could not start the Push Server: ' . $ex->getMessage() . ', ' . $ex->getTraceAsString() );
-			Class_Perfecty_Push_Lib_Utils::show_message( esc_html( 'Could not start the Push Server, check the PHP error logs for more information.', 'perfecty-push-notifications' ), 'warning' );
-			Class_Perfecty_Push_Lib_Utils::disable();
+			Perfecty_Push_Lib_Utils::show_message( esc_html( 'Could not start the Push Server, check the PHP error logs for more information.', 'perfecty-push-notifications' ), 'warning' );
+			Perfecty_Push_Lib_Utils::disable();
 			throw $ex;
 		}
 		restore_error_handler();
@@ -116,7 +114,7 @@ class Perfecty_Push_Lib_Push_Server {
 		$payload = apply_filters( 'perfecty_push_custom_payload', $payload );
 		$payload = json_encode( $payload );
 
-		if ( Class_Perfecty_Push_Lib_Utils::is_disabled() ) {
+		if ( Perfecty_Push_Lib_Utils::is_disabled() ) {
 			Log::error( 'Perfecty Push is disabled, fix the issues already reported.' );
 			return false;
 		}
@@ -376,7 +374,7 @@ class Perfecty_Push_Lib_Push_Server {
 
 		foreach ( $users as $item ) {
 			Log::debug( 'Enqueuing notification to user id=' . $item->id );
-			$push_user = new Subscription(
+			$push_user = Perfecty_Push_External_Webpush::subscription(
 				$item->endpoint,
 				$item->key_p256dh,
 				$item->key_auth

--- a/lib/class-perfecty-push-lib-utils.php
+++ b/lib/class-perfecty-push-lib-utils.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Class Class_Perfecty_Push_Lib_Utils
+ * Class Perfecty_Push_Lib_Utils
  *
  * Contains utilities for checking the Push Server and show messages
  */
-class Class_Perfecty_Push_Lib_Utils {
+class Perfecty_Push_Lib_Utils {
 
 
 	/**

--- a/perfecty-push.php
+++ b/perfecty-push.php
@@ -79,11 +79,11 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-perfecty-push.php';
 require plugin_dir_path( __FILE__ ) . 'lib/class-perfecty-push-lib-utils.php';
 if ( version_compare( PHP_VERSION, '7.2.0', '>=' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
-	Class_Perfecty_Push_Lib_Utils::check_gmp();
+	Perfecty_Push_Lib_Utils::check_gmp();
 } else {
 	error_log( sprintf( 'Wrong PHP version: %s', PHP_VERSION ) );
-	Class_Perfecty_Push_Lib_Utils::show_message( esc_html( 'Perfecty Push requires PHP >= 7.2.0', 'perfecty-push-notifications' ), 'error' );
-	Class_Perfecty_Push_Lib_Utils::disable();
+	Perfecty_Push_Lib_Utils::show_message( esc_html( 'Perfecty Push requires PHP >= 7.2.0', 'perfecty-push-notifications' ), 'error' );
+	Perfecty_Push_Lib_Utils::disable();
 }
 
 /**

--- a/public/class-perfecty-push-users.php
+++ b/public/class-perfecty-push-users.php
@@ -17,8 +17,7 @@
  * @author     Rowinson Gallego <rwn.gallego@gmail.com>
  */
 
-use Minishlink\WebPush\Subscription;
-use Ramsey\Uuid\Uuid;
+use Perfecty_Push_External_Uuid as Uuid;
 use Perfecty_Push_Lib_Log as Log;
 
 class Perfecty_Push_Users {
@@ -60,7 +59,7 @@ class Perfecty_Push_Users {
 
 			// check if this is a valid subscription
 			try {
-				new Subscription( $endpoint, $key_p256dh, $key_auth );
+				Perfecty_Push_External_Webpush::subscription( $endpoint, $key_p256dh, $key_auth );
 			} catch ( Exception $e ) {
 				Log::error( 'Invalid subscription: ' . $e->getMessage() );
 				return new WP_Error( 'validation_error', __( 'Invalid subscription parameters', 'perfecty-push-notifications' ), array( 'status' => 400 ) );

--- a/public/partials/perfecty-push-public-head.php
+++ b/public/partials/perfecty-push-public-head.php
@@ -11,7 +11,7 @@ $perfecty_push_unregister_conflicts_expression = ! empty( $options['unregister_c
 $perfecty_push_prompt_icon_url                 = isset( $options['notifications_default_icon'] ) && ! empty( $options['notifications_default_icon'] ) ? wp_get_attachment_url( $options['notifications_default_icon'] ) : '';
 $perfecty_push_visits_to_display_prompt        = isset( $options['visits_to_display_prompt'] ) && $options['visits_to_display_prompt'] ? $options['visits_to_display_prompt'] : 0;
 
-if ( Class_Perfecty_Push_Lib_Utils::is_disabled() ||
+if ( Perfecty_Push_Lib_Utils::is_disabled() ||
 	( ! isset( $options['widget_enabled'] ) || $options['widget_enabled'] == 0 ) ) {
 	$perfecty_push_enabled = false;
 } else {

--- a/tests/test-db.php
+++ b/tests/test-db.php
@@ -9,7 +9,7 @@
  * Test the Perfecty_Push_Lib_Db
  */
 
-use Ramsey\Uuid\Uuid;
+use Perfecty_Push_External_Uuid as Uuid;
 
 class DbTest extends WP_UnitTestCase {
 

--- a/tests/test-logger.php
+++ b/tests/test-logger.php
@@ -1,7 +1,5 @@
 <?php
 
-use Minishlink\WebPush\WebPush;
-
 /**
  * Class LoggerTest
  *

--- a/tests/test-push-server.php
+++ b/tests/test-push-server.php
@@ -1,7 +1,5 @@
 <?php
 
-use Minishlink\WebPush\WebPush;
-
 /**
  * Class PushServerTest
  *
@@ -34,10 +32,10 @@ class PushServerTest extends WP_UnitTestCase {
                 return false; // we raise it to the next handler otherwise
             }
         );
-		$webpush         = new WebPush();
+		$webpush         = Perfecty_Push_External_Webpush::get();
         restore_error_handler();
 
-		$vapid_generator = array( 'Minishlink\WebPush\VAPID', 'createVapidKeys' );
+		$vapid_generator = array( 'Perfecty_Push_External_Webpush', 'createVapidKeys' );
 		Perfecty_Push_Lib_Push_Server::bootstrap( array(), $vapid_generator, $webpush );
 
 		\Mockery::close();

--- a/tests/test-rest-get-user.php
+++ b/tests/test-rest-get-user.php
@@ -5,6 +5,8 @@
  * @package Perfecty_Push
  */
 
+use Perfecty_Push_External_Uuid as Uuid;
+
 /**
  * Test the Perfecty_Push_Users class
  */
@@ -48,7 +50,7 @@ class RestGetUserTest extends WP_UnitTestCase {
 	 * Test get user not found
 	 */
 	public function test_get_user_not_found() {
-	    $uuid = \Ramsey\Uuid\Uuid::uuid4();
+	    $uuid = Uuid::uuid4();
 		$data        = array(
 			'user_id'   => $uuid->toString(),
 		);
@@ -83,7 +85,7 @@ class RestGetUserTest extends WP_UnitTestCase {
 	 * Test get user with invalid nonce
 	 */
 	public function test_get_user_invalid_nonce() {
-        $uuid = \Ramsey\Uuid\Uuid::uuid4();
+        $uuid = Uuid::uuid4();
         $data        = array(
             'user_id'   => $uuid->toString(),
         );

--- a/tests/test-rest-registration.php
+++ b/tests/test-rest-registration.php
@@ -1,8 +1,5 @@
 <?php
 
-use Minishlink\WebPush\WebPush;
-use Ramsey\Uuid\Uuid;
-
 /**
  * Class RestRegistrationTest
  *
@@ -88,8 +85,8 @@ class RestRegistrationTest extends WP_UnitTestCase {
 		$this->assertArraySubset( $expected, (array) $users[0] );
 
 		// clean up.
-		$webpush         = new WebPush();
-		$vapid_generator = array( 'Minishlink\WebPush\VAPID', 'createVapidKeys' );
+		$webpush         = Perfecty_Push_External_Webpush::get();
+		$vapid_generator = array( 'Perfecty_Push_External_Webpush', 'createVapidKeys' );
 		Perfecty_Push_Lib_Push_Server::bootstrap( array(), $vapid_generator, $webpush );
 
 	}

--- a/tests/test-rest-unregister-user.php
+++ b/tests/test-rest-unregister-user.php
@@ -5,6 +5,8 @@
  * @package Perfecty_Push
  */
 
+use Perfecty_Push_External_Uuid as Uuid;
+
 /**
  * Test the Perfecty_Push_Users class
  */
@@ -46,7 +48,7 @@ class RestUnregisterUserTest extends WP_UnitTestCase {
 	 * Test unregister user not found
 	 */
 	public function test_unregister_user_not_found() {
-	    $uuid = \Ramsey\Uuid\Uuid::uuid4();
+	    $uuid = Uuid::uuid4();
 		$data        = array(
 			'user_id'   => $uuid->toString(),
 		);
@@ -89,7 +91,7 @@ class RestUnregisterUserTest extends WP_UnitTestCase {
 	 * Test unregister user with invalid nonce
 	 */
 	public function test_unregister_user_invalid_nonce() {
-        $uuid = \Ramsey\Uuid\Uuid::uuid4();
+        $uuid = Uuid::uuid4();
         $data        = array(
             'user_id'   => $uuid->toString(),
         );


### PR DESCRIPTION
 Use the external composer libraries only when necessary to avoid potential conflicts.

Fixes #111 