### PR TITLE
Feature/recurring notifications

### DIFF
--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -763,13 +763,15 @@ class Perfecty_Push_Admin {
 				$item['perfecty-push-send-notification-url-to-open'] = sanitize_text_field( $item['perfecty-push-send-notification-url-to-open'] );
 				$item['perfecty-push-send-notification-image']       = sanitize_text_field( $item['perfecty-push-send-notification-image'] );
 				$item['perfecty-push-send-notification-timeoffset']  = sanitize_text_field( $item['perfecty-push-send-notification-timeoffset'] );
-				$item['perfecty-push-send-notification-recurring']	 = sanitize_key( $item['perfecty-push-send-notification-recurring'] );
+				$item['perfecty-push-send-notification-recurring']   = sanitize_key( $item['perfecty-push-send-notification-recurring'] );
 
 				$payload        = Perfecty_Push_Lib_Payload::build( $item['perfecty-push-send-notification-message'], $item['perfecty-push-send-notification-title'], $item['perfecty-push-send-notification-image'], $item['perfecty-push-send-notification-url-to-open'] );
 				$timeoffset     = intval( $item['perfecty-push-send-notification-timeoffset'] );
 				$scheduled_time = self::calculate_scheduled_time_from_offset( $timeoffset );
 				if(!empty($item['perfecty-push-send-notification-recurring'])){
 					$recurring = $item['perfecty-push-send-notification-recurring'] === 'yes' ? 1 : 0;
+				}else{
+					$recurring = 0;
 				}
 
 				// send notification

--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -749,6 +749,7 @@ class Perfecty_Push_Admin {
 			'perfecty-push-send-notification-url-to-open' => '',
 			'perfecty-push-send-notification-image'       => '',
 			'perfecty-push-send-notification-timeoffset'  => '',
+			'perfecty-push-send-notification-recurring'  => '',
 		);
 
 		if ( isset( $_REQUEST['nonce'] ) && wp_verify_nonce( $_REQUEST['nonce'], 'perfecty_push_send_notification' ) ) {
@@ -762,13 +763,17 @@ class Perfecty_Push_Admin {
 				$item['perfecty-push-send-notification-url-to-open'] = sanitize_text_field( $item['perfecty-push-send-notification-url-to-open'] );
 				$item['perfecty-push-send-notification-image']       = sanitize_text_field( $item['perfecty-push-send-notification-image'] );
 				$item['perfecty-push-send-notification-timeoffset']  = sanitize_text_field( $item['perfecty-push-send-notification-timeoffset'] );
+				$item['perfecty-push-send-notification-recurring']	 = sanitize_key( $item['perfecty-push-send-notification-recurring'] );
 
 				$payload        = Perfecty_Push_Lib_Payload::build( $item['perfecty-push-send-notification-message'], $item['perfecty-push-send-notification-title'], $item['perfecty-push-send-notification-image'], $item['perfecty-push-send-notification-url-to-open'] );
 				$timeoffset     = intval( $item['perfecty-push-send-notification-timeoffset'] );
 				$scheduled_time = self::calculate_scheduled_time_from_offset( $timeoffset );
+				if(!empty($item['perfecty-push-send-notification-recurring'])){
+					$recurring = $item['perfecty-push-send-notification-recurring'] === 'yes' ? 1 : 0;
+				}
 
 				// send notification
-				$result = Perfecty_Push_Lib_Push_Server::schedule_broadcast_async( $payload, $scheduled_time );
+				$result = Perfecty_Push_Lib_Push_Server::schedule_broadcast_async( $payload, $scheduled_time, $recurring );
 
 				if ( $result === false ) {
 					  $notice = esc_html__( 'Could not schedule the notification, check the logs', 'perfecty-push-notifications' );

--- a/admin/partials/perfecty-push-admin-send-notification-metabox.php
+++ b/admin/partials/perfecty-push-admin-send-notification-metabox.php
@@ -52,9 +52,8 @@
 			<input id="perfecty-push-send-notification-scheduled-date" name="perfecty-push-send-notification-scheduled-date" type="date" class="perfecty-push-notification-date" value="" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}" placeholder="2021-05-26" disabled="disabled"/>
 			<input id="perfecty-push-send-notification-scheduled-time" name="perfecty-push-send-notification-scheduled-time" type="time" class="perfecty-push-notification-time" value="" pattern="[0-9]{2}:[0-9]{2}:[0-9]{2}" placeholder="00:00:00" step=1 disabled="disabled"/>
 			<input id="perfecty-push-send-notification-timeoffset" name="perfecty-push-send-notification-timeoffset" type="hidden" value=""/>
-			<label for="perfecty-push-send-notification-recurring-notification"><?php printf( esc_html__( 'Recurring notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(Keeps recurring on the next day same time)', 'perfecty-push-notifications' ) ); ?></i></label>
-			<br />
 			<input id="perfecty-push-send-notification-recurring-notification" name="perfecty-push-send-notification-recurring-notification" type="checkbox"/>
+			<label for="perfecty-push-send-notification-recurring-notification"><?php printf( esc_html__( 'Recurring notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(Keeps recurring on the next day same time)', 'perfecty-push-notifications' ) ); ?></i></label>
 		</p>
 	</div>
 </div>

--- a/admin/partials/perfecty-push-admin-send-notification-metabox.php
+++ b/admin/partials/perfecty-push-admin-send-notification-metabox.php
@@ -46,12 +46,15 @@
 	</div>
 	<div>
 		<p>
-		<label for="perfecty-push-send-notification-schedule-notification"><?php printf( esc_html__( 'Schedule notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(default: now)', 'perfecty-push-notifications' ) ); ?></i></label>
-		<br />
-		<input id="perfecty-push-send-notification-schedule-notification" name="perfecty-push-send-notification-schedule-notification" type="checkbox"/>
-		<input id="perfecty-push-send-notification-scheduled-date" name="perfecty-push-send-notification-scheduled-date" type="date" class="perfecty-push-notification-date" value="" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}" placeholder="2021-05-26" disabled="disabled"/>
-		<input id="perfecty-push-send-notification-scheduled-time" name="perfecty-push-send-notification-scheduled-time" type="time" class="perfecty-push-notification-time" value="" pattern="[0-9]{2}:[0-9]{2}:[0-9]{2}" placeholder="00:00:00" step=1 disabled="disabled"/>
-		<input id="perfecty-push-send-notification-timeoffset" name="perfecty-push-send-notification-timeoffset" type="hidden" value=""/>
+			<label for="perfecty-push-send-notification-schedule-notification"><?php printf( esc_html__( 'Schedule notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(default: now)', 'perfecty-push-notifications' ) ); ?></i></label>
+			<br />
+			<input id="perfecty-push-send-notification-schedule-notification" name="perfecty-push-send-notification-schedule-notification" type="checkbox"/>
+			<input id="perfecty-push-send-notification-scheduled-date" name="perfecty-push-send-notification-scheduled-date" type="date" class="perfecty-push-notification-date" value="" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}" placeholder="2021-05-26" disabled="disabled"/>
+			<input id="perfecty-push-send-notification-scheduled-time" name="perfecty-push-send-notification-scheduled-time" type="time" class="perfecty-push-notification-time" value="" pattern="[0-9]{2}:[0-9]{2}:[0-9]{2}" placeholder="00:00:00" step=1 disabled="disabled"/>
+			<input id="perfecty-push-send-notification-timeoffset" name="perfecty-push-send-notification-timeoffset" type="hidden" value=""/>
+			<label for="perfecty-push-send-notification-recurring-notification"><?php printf( esc_html__( 'Recurring notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(Keeps recurring on the next day same time)', 'perfecty-push-notifications' ) ); ?></i></label>
+			<br />
+			<input id="perfecty-push-send-notification-recurring-notification" name="perfecty-push-send-notification-recurring-notification" type="checkbox"/>
 		</p>
 	</div>
 </div>

--- a/admin/partials/perfecty-push-admin-send-notification-metabox.php
+++ b/admin/partials/perfecty-push-admin-send-notification-metabox.php
@@ -52,8 +52,8 @@
 			<input id="perfecty-push-send-notification-scheduled-date" name="perfecty-push-send-notification-scheduled-date" type="date" class="perfecty-push-notification-date" value="" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}" placeholder="2021-05-26" disabled="disabled"/>
 			<input id="perfecty-push-send-notification-scheduled-time" name="perfecty-push-send-notification-scheduled-time" type="time" class="perfecty-push-notification-time" value="" pattern="[0-9]{2}:[0-9]{2}:[0-9]{2}" placeholder="00:00:00" step=1 disabled="disabled"/>
 			<input id="perfecty-push-send-notification-timeoffset" name="perfecty-push-send-notification-timeoffset" type="hidden" value=""/>
-			<input id="perfecty-push-send-notification-recurring-notification" name="perfecty-push-send-notification-recurring-notification" type="checkbox" value="yes" />
-			<label for="perfecty-push-send-notification-recurring-notification"><?php printf( esc_html__( 'Recurring notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(Keeps recurring on the next day same time)', 'perfecty-push-notifications' ) ); ?></i></label>
+			<input id="perfecty-push-send-notification-recurring" name="perfecty-push-send-notification-recurring" type="checkbox" value="yes" />
+			<label for="perfecty-push-send-notification-recurring"><?php printf( esc_html__( 'Recurring notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(Keeps recurring on the next day same time)', 'perfecty-push-notifications' ) ); ?></i></label>
 		</p>
 	</div>
 </div>

--- a/admin/partials/perfecty-push-admin-send-notification-metabox.php
+++ b/admin/partials/perfecty-push-admin-send-notification-metabox.php
@@ -52,7 +52,7 @@
 			<input id="perfecty-push-send-notification-scheduled-date" name="perfecty-push-send-notification-scheduled-date" type="date" class="perfecty-push-notification-date" value="" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}" placeholder="2021-05-26" disabled="disabled"/>
 			<input id="perfecty-push-send-notification-scheduled-time" name="perfecty-push-send-notification-scheduled-time" type="time" class="perfecty-push-notification-time" value="" pattern="[0-9]{2}:[0-9]{2}:[0-9]{2}" placeholder="00:00:00" step=1 disabled="disabled"/>
 			<input id="perfecty-push-send-notification-timeoffset" name="perfecty-push-send-notification-timeoffset" type="hidden" value=""/>
-			<input id="perfecty-push-send-notification-recurring-notification" name="perfecty-push-send-notification-recurring-notification" type="checkbox"/>
+			<input id="perfecty-push-send-notification-recurring-notification" name="perfecty-push-send-notification-recurring-notification" type="checkbox" value="yes" />
 			<label for="perfecty-push-send-notification-recurring-notification"><?php printf( esc_html__( 'Recurring notification', 'perfecty-push-notifications' ) ); ?> <i><?php printf( esc_html__( '(Keeps recurring on the next day same time)', 'perfecty-push-notifications' ) ); ?></i></label>
 		</p>
 	</div>

--- a/lib/class-perfecty-push-lib-db.php
+++ b/lib/class-perfecty-push-lib-db.php
@@ -8,7 +8,7 @@ use Perfecty_Push_External_Uuid as Uuid;
 class Perfecty_Push_Lib_Db {
 
 	private static $allowed_users_fields         = 'id,uuid,wp_user_id,endpoint,key_auth,key_p256dh,remote_ip,created_at';
-	private static $allowed_notifications_fields = 'id,payload,total,succeeded,failed,last_cursor,batch_size,status,is_taken,created_at,finished_at,last_execution_at,scheduled_at';
+	private static $allowed_notifications_fields = 'id,payload,total,succeeded,failed,last_cursor,batch_size,status,is_taken,created_at,finished_at,last_execution_at,scheduled_at,recurring';
 	private static $allowed_logs_fields          = 'level,message,created_at';
 
 	public const NOTIFICATIONS_STATUS_SCHEDULED = 'scheduled';
@@ -366,7 +366,7 @@ class Perfecty_Push_Lib_Db {
 	 *
 	 * @return $inserted_id or false if error
 	 */
-	public static function create_notification( $payload, $status = self::NOTIFICATIONS_STATUS_SCHEDULED, $total = 0, $batch_size = Perfecty_Push_Lib_Push_Server::DEFAULT_BATCH_SIZE, $scheduled_at = null ) {
+	public static function create_notification( $payload, $status = self::NOTIFICATIONS_STATUS_SCHEDULED, $total = 0, $batch_size = Perfecty_Push_Lib_Push_Server::DEFAULT_BATCH_SIZE, $scheduled_at = null, $recurring = null ) {
 		global $wpdb;
 
 		$scheduled_at = $scheduled_at == null ? null : date( 'Y-m-d H:i:s', $scheduled_at );
@@ -378,6 +378,7 @@ class Perfecty_Push_Lib_Db {
 				'total'        => $total,
 				'batch_size'   => $batch_size,
 				'scheduled_at' => $scheduled_at,
+				'recurring'    => $recurring,
 			)
 		);
 

--- a/lib/class-perfecty-push-lib-db.php
+++ b/lib/class-perfecty-push-lib-db.php
@@ -52,42 +52,43 @@ class Perfecty_Push_Lib_Db {
 
 		// We execute the queries per table
 		$sql = "CREATE TABLE $user_table (
-          id int(11) NOT NULL AUTO_INCREMENT,
-          wp_user_id int(11) NULL,
-          uuid char(36) NOT NULL,
-          remote_ip varchar(46) DEFAULT '',
-          endpoint varchar(500) NOT NULL,
-          key_auth varchar(100) NOT NULL UNIQUE,
-          key_p256dh varchar(100) NOT NULL UNIQUE,
-          created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
-          PRIMARY KEY  (id),
-          UNIQUE KEY users_uuid_uk (uuid)
-        ) $charset;";
+		  id int(11) NOT NULL AUTO_INCREMENT,
+		  wp_user_id int(11) NULL,
+		  uuid char(36) NOT NULL,
+		  remote_ip varchar(46) DEFAULT '',
+		  endpoint varchar(500) NOT NULL,
+		  key_auth varchar(100) NOT NULL UNIQUE,
+		  key_p256dh varchar(100) NOT NULL UNIQUE,
+		  created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+		  PRIMARY KEY  (id),
+		  UNIQUE KEY users_uuid_uk (uuid)
+		) $charset;";
 		dbDelta( $sql );
 
 		$sql = "CREATE TABLE $notifications_table (
-          id int(11) NOT NULL AUTO_INCREMENT,
-          payload varchar(2000) NOT NULL,
-          total int(11) DEFAULT 0 NOT NULL,
-          succeeded int(11) DEFAULT 0 NOT NULL,
-          failed int(11) DEFAULT 0 NOT NULL,
-          last_cursor int(11) DEFAULT 0 NOT NULL,
-          batch_size int(11) DEFAULT 0 NOT NULL,
-          status varchar(15) DEFAULT 'scheduled' NOT NULL,
-          is_taken tinyint(1) DEFAULT 0 NOT NULL,
-          created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
-          last_execution_at datetime NULL,
-          scheduled_at datetime NULL,
-          finished_at datetime NULL,
-          PRIMARY KEY  (id)
-        ) $charset;";
+		  id int(11) NOT NULL AUTO_INCREMENT,
+		  payload varchar(2000) NOT NULL,
+		  total int(11) DEFAULT 0 NOT NULL,
+		  succeeded int(11) DEFAULT 0 NOT NULL,
+		  failed int(11) DEFAULT 0 NOT NULL,
+		  last_cursor int(11) DEFAULT 0 NOT NULL,
+		  batch_size int(11) DEFAULT 0 NOT NULL,
+		  status varchar(15) DEFAULT 'scheduled' NOT NULL,
+		  is_taken tinyint(1) DEFAULT 0 NOT NULL,
+		  created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+		  last_execution_at datetime NULL,
+		  scheduled_at datetime NULL,
+		  finished_at datetime NULL,
+  		  recurring boolean DEFAULT 0 NOT NULL,
+		  PRIMARY KEY  (id)
+		) $charset;";
 		dbDelta( $sql );
 
 		$sql = "CREATE TABLE $logs_table (
-          level varchar(10) DEFAULT 'debug',
-          message varchar(2000) NOT NULL,
-          created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL
-        ) $charset;";
+		  level varchar(10) DEFAULT 'debug',
+		  message varchar(2000) NOT NULL,
+		  created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL
+		) $charset;";
 		dbDelta( $sql );
 
 		if ( $db_version != PERFECTY_PUSH_DB_VERSION ) {

--- a/lib/class-perfecty-push-lib-db.php
+++ b/lib/class-perfecty-push-lib-db.php
@@ -105,6 +105,11 @@ class Perfecty_Push_Lib_Db {
 				// the counters have been adjusted, we migrate the old stats
 				$wpdb->query( "UPDATE $notifications_table SET failed = total - succeeded" );
 			}
+			if ( $db_version == 7 ) {
+				if ( $wpdb->get_var( "SHOW INDEX FROM $notifications_table WHERE Key_name='recurring'" ) === null ) {
+					$wpdb->query( "ALTER TABLE $notifications_table ADD recurring boolean DEFAULT 0 NOT NULL" );
+				}
+			}
 
 			update_option( 'perfecty_push_db_version', PERFECTY_PUSH_DB_VERSION );
 		}

--- a/lib/class-perfecty-push-lib-push-server.php
+++ b/lib/class-perfecty-push-lib-push-server.php
@@ -346,7 +346,7 @@ class Perfecty_Push_Lib_Push_Server {
 				$notification_id = Perfecty_Push_Lib_Db::create_notification( $notification->payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $notification->batch_size, $scheduled_time, $notification->recurring );
 
 				self::schedule_job( $notification_id, $scheduled_time );
-				do_action( 'perfecty_push_broadcast_scheduled', $payload );
+				do_action( 'perfecty_push_broadcast_scheduled', $notification->payload );
 			}
 
 			

--- a/lib/class-perfecty-push-lib-push-server.php
+++ b/lib/class-perfecty-push-lib-push-server.php
@@ -98,7 +98,7 @@ class Perfecty_Push_Lib_Push_Server {
 	 * @return int | bool $notification_id if success, false otherwise
 	 * @throws Exception
 	 */
-	public static function schedule_broadcast_async( $payload, $scheduled_time = null ) {
+	public static function schedule_broadcast_async( $payload, $scheduled_time = null, $recurring = null ) {
 		Log::info( 'Scheduling a broadcast notification' );
 		Log::debug( print_r( $payload, true ) );
 
@@ -137,7 +137,7 @@ class Perfecty_Push_Lib_Push_Server {
 				$scheduled_time = $date->getTimestamp();
 			}
 			$total_users     = Perfecty_Push_Lib_Db::get_total_users();
-			$notification_id = Perfecty_Push_Lib_Db::create_notification( $payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $batch_size, $scheduled_time );
+			$notification_id = Perfecty_Push_Lib_Db::create_notification( $payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $batch_size, $scheduled_time, $recurring );
 			if ( ! $notification_id ) {
 				Log::error( 'Could not schedule the notification.' );
 				return false;
@@ -337,14 +337,13 @@ class Perfecty_Push_Lib_Push_Server {
 			$result                          = Perfecty_Push_Lib_Db::update_notification( $notification );
 
 			//Creates a notification for the next day if recurring is checked
-			//if($notification->recurring){
-			if(1===1){
+			if($notification->recurring){
 				$date           = new DateTime( $notification->scheduled_at );
 				$datePlusDay 	= $date->add(new DateInterval('P1D'));
 				$scheduled_time = $datePlusDay->getTimeStamp();
 
 				$total_users     = Perfecty_Push_Lib_Db::get_total_users();
-				$notification_id = Perfecty_Push_Lib_Db::create_notification( $notification->payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $notification->batch_size, $scheduled_time );
+				$notification_id = Perfecty_Push_Lib_Db::create_notification( $notification->payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $notification->batch_size, $scheduled_time, $notification->recurring );
 
 				self::schedule_job( $notification_id, $scheduled_time );
 				do_action( 'perfecty_push_broadcast_scheduled', $payload );

--- a/lib/class-perfecty-push-lib-push-server.php
+++ b/lib/class-perfecty-push-lib-push-server.php
@@ -340,7 +340,8 @@ class Perfecty_Push_Lib_Push_Server {
 			//if($notification->recurring){
 			if(1===1){
 				$date           = new DateTime( $notification->scheduled_at );
-				$scheduled_time = $date->add(new DateInterval('P1D'));
+				$datePlusDay 	= $date->add(new DateInterval('P1D'));
+				$scheduled_time = $datePlusDay->getTimeStamp();
 
 				$total_users     = Perfecty_Push_Lib_Db::get_total_users();
 				$notification_id = Perfecty_Push_Lib_Db::create_notification( $notification->payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $notification->batch_size, $scheduled_time );

--- a/lib/class-perfecty-push-lib-push-server.php
+++ b/lib/class-perfecty-push-lib-push-server.php
@@ -336,6 +336,20 @@ class Perfecty_Push_Lib_Push_Server {
 			$notification->last_execution_at = current_time( 'mysql', 1 );
 			$result                          = Perfecty_Push_Lib_Db::update_notification( $notification );
 
+			//Creates a notification for the next day if recurring is checked
+			//if($notification->recurring){
+			if(1===1){
+				$date           = new DateTime( $notification->scheduled_at );
+				$scheduled_time = $date->add(new DateInterval('P1D'));
+
+				$total_users     = Perfecty_Push_Lib_Db::get_total_users();
+				$notification_id = Perfecty_Push_Lib_Db::create_notification( $notification->payload, Perfecty_Push_Lib_Db::NOTIFICATIONS_STATUS_SCHEDULED, $total_users, $notification->batch_size, $scheduled_time );
+
+				self::schedule_job( $notification_id, $scheduled_time );
+				do_action( 'perfecty_push_broadcast_scheduled', $payload );
+			}
+
+			
 			Log::info( 'Notification cycle for id=' . $notification_id . ' sent. Cursor: ' . $notification->last_cursor . ', Succeeded: ' . $total_succeeded . ', Failed: ' . $total_failed );
 			if ( ! $result ) {
 				Log::error( 'Could not update the notification after sending one batch' );

--- a/perfecty-push.php
+++ b/perfecty-push.php
@@ -39,7 +39,7 @@ define( 'PERFECTY_PUSH_VERSION', '1.6.1' );
 /**
  * DB Version of the plugin
  */
-define( 'PERFECTY_PUSH_DB_VERSION', 6 );
+define( 'PERFECTY_PUSH_DB_VERSION', 7 );
 
 /**
  * The basename of the plugin


### PR DESCRIPTION
Added in a recurring checkbox for notifications to happen daily at the same time. It just creates a new scheduled job right after the existing job completed. Working on adding in more toggles for weekly, monthly and yearly. Wanted to see if this was something that was useful and possibly get it merged in. Let me know if you see any changes that need to be made! Appreciate the plugin!