### PR TITLE
Add `Perfecty_Push_Integration` class to distributed plugin

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -93,7 +93,7 @@ create_dist() {
   create_sdk_dist
   rm -rf $DIST_PATH
   mkdir -p $SVN_PATH $OUTPUT_PATH
-  cp -Rp admin includes external languages lib public composer.json composer.lock index.php LICENSE.txt perfecty-push.php README.txt uninstall.php $OUTPUT_PATH
+  cp -Rp admin includes integration external languages lib public composer.json composer.lock index.php LICENSE.txt perfecty-push.php README.txt uninstall.php $OUTPUT_PATH
   (cd $OUTPUT_PATH && composer install --quiet --no-dev --optimize-autoloader)
   cp index.php $OUTPUT_PATH/vendor/
 }


### PR DESCRIPTION
The documented `Perfectly_Push_Integration` class is not included in the WordPress.org zip file, see:

https://plugins.trac.wordpress.org/browser/perfecty-push-notifications/tags/1.6.2

This PR adds the `integration` directory to the `run.sh` `create_dist()` command.

TBH, I think the public functions should be in a file called `functions.php` and not in a class at all.