### PR TITLE
Prevent calls to load_plugin_textdomain() too early

### DIFF
--- a/perfecty-push.php
+++ b/perfecty-push.php
@@ -95,7 +95,12 @@ if ( version_compare( PHP_VERSION, '7.2.0', '>=' ) ) {
  * @since    1.0.0
  */
 function run_perfecty_push() {
-	$plugin = new Perfecty_Push();
-	$plugin->run();
+	add_action(
+		'init',
+		function () {
+			$plugin = new Perfecty_Push();
+			$plugin->run();
+		}
+	);
 }
 run_perfecty_push();


### PR DESCRIPTION
See: https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/

Since WP version 6.7 when WP_DEBUG is true, the plugin sends a Warning as:
`PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>perfecty-push-notifications</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /MYABSPATH/wp-includes/functions.php on line 6121`
This PR prevents the plugin to be run before init and to load translations too early.