### PR TITLE
Define translated constants after loading textdomain

### DIFF
--- a/includes/class-perfecty-push-i18n.php
+++ b/includes/class-perfecty-push-i18n.php
@@ -38,6 +38,59 @@ class Perfecty_Push_i18n {
 			false,
 			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
 		);
+		
+		// Define text constants after textdomain is loaded
+		$this->define_text_constants();
+	}
+
+	/**
+	 * Define translatable text constants.
+	 *
+	 * @since    1.6.5
+	 */
+	public function define_text_constants() {
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_DIALOG_TITLE' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_DIALOG_TITLE',
+				esc_html__( 'Do you want to receive notifications?', 'perfecty-push-notifications' )
+			);
+		}
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_DIALOG_CONTINUE' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_DIALOG_CONTINUE',
+				esc_html__( 'Continue', 'perfecty-push-notifications' )
+			);
+		}
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_DIALOG_CANCEL' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_DIALOG_CANCEL',
+				esc_html__( 'Not now', 'perfecty-push-notifications' )
+			);
+		}
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_TITLE' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_SETTINGS_TITLE',
+				esc_html__( 'Notifications preferences', 'perfecty-push-notifications' )
+			);
+		}
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_OPT_IN' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_SETTINGS_OPT_IN',
+				esc_html__( 'I want to receive notifications', 'perfecty-push-notifications' )
+			);
+		}
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_UPDATE_ERROR' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_SETTINGS_UPDATE_ERROR',
+				esc_html__( 'Could not change the preference, try again', 'perfecty-push-notifications' )
+			);
+		}
+		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_WELCOME_MESSAGE' ) ) {
+			define(
+				'PERFECTY_PUSH_OPTIONS_SETTINGS_WELCOME_MESSAGE',
+				esc_html__( 'Congratulations, you\'re now subscribed!', 'perfecty-push-notifications' )
+			);
+		}
 	}
 
 

--- a/includes/class-perfecty-push-i18n.php
+++ b/includes/class-perfecty-push-i18n.php
@@ -34,7 +34,7 @@ class Perfecty_Push_i18n {
 	 */
 	public function load_plugin_textdomain() {
 		load_plugin_textdomain(
-			'perfecty-push',
+			'perfecty-push-notifications',
 			false,
 			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
 		);

--- a/includes/class-perfecty-push.php
+++ b/includes/class-perfecty-push.php
@@ -216,7 +216,7 @@ class Perfecty_Push {
 	private function set_locale() {
 		$plugin_i18n = new Perfecty_Push_i18n();
 
-		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+		$this->loader->add_action( 'init', $plugin_i18n, 'load_plugin_textdomain' );
 	}
 
 	/**

--- a/includes/class-perfecty-push.php
+++ b/includes/class-perfecty-push.php
@@ -109,49 +109,6 @@ class Perfecty_Push {
 			define( 'PERFECTY_PUSH_VAPID_PRIVATE_KEY', $vapid_private_key );
 		}
 
-		/* Default control texts */
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_DIALOG_TITLE' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_DIALOG_TITLE',
-				esc_html__( 'Do you want to receive notifications?', 'perfecty-push-notifications' )
-			);
-		}
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_DIALOG_CONTINUE' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_DIALOG_CONTINUE',
-				esc_html__( 'Continue', 'perfecty-push-notifications' )
-			);
-		}
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_DIALOG_CANCEL' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_DIALOG_CANCEL',
-				esc_html__( 'Not now', 'perfecty-push-notifications' )
-			);
-		}
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_TITLE' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_SETTINGS_TITLE',
-				esc_html__( 'Notifications preferences', 'perfecty-push-notifications' )
-			);
-		}
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_OPT_IN' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_SETTINGS_OPT_IN',
-				esc_html__( 'I want to receive notifications', 'perfecty-push-notifications' )
-			);
-		}
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_UPDATE_ERROR' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_SETTINGS_UPDATE_ERROR',
-				esc_html__( 'Could not change the preference, try again', 'perfecty-push-notifications' )
-			);
-		}
-		if ( ! defined( 'PERFECTY_PUSH_OPTIONS_SETTINGS_WELCOME_MESSAGE' ) ) {
-			define(
-				'PERFECTY_PUSH_OPTIONS_SETTINGS_WELCOME_MESSAGE',
-				esc_html__( 'Congratulations, you\'re now subscribed!', 'perfecty-push-notifications' )
-			);
-		}
 		if ( ! defined( 'PERFECTY_PUSH_UNREGISTER_CONFLICTS_EXPRESSION' ) ) {
 			define(
 				'PERFECTY_PUSH_UNREGISTER_CONFLICTS_EXPRESSION',


### PR DESCRIPTION
This defines some of the constants that require translated text after the `textdomain` is loaded to remove the warning:

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. 
Translation loading for the perfecty-push-notifications domain was triggered too early.
This is usually an indicator for some code in the plugin or theme running too early.
Translations should be loaded at the init action or later.
```